### PR TITLE
Handle hpack projects:

### DIFF
--- a/src/Stack2Cabal/Cabal.hs
+++ b/src/Stack2Cabal/Cabal.hs
@@ -26,7 +26,7 @@ writeCabalProjectFile remPkgsDir parsedYaml@ParsedYaml{..} = do
 
       -- .. local packages
       hPutStrLn h "-- local packages"
-      do cabalFiles <- mapM findCabalFile stackLocalPackages
+      do cabalFiles <- mapM findOrMakeCabalFile stackLocalPackages
          forM_ (zip (True : repeat False) cabalFiles) $ \(isFirst, cabalFile) ->
            hPutStrLn h $ concat [
                if isFirst then "    "

--- a/src/Stack2Cabal/LocalPkgs.hs
+++ b/src/Stack2Cabal/LocalPkgs.hs
@@ -1,9 +1,10 @@
 module Stack2Cabal.LocalPkgs (
-    findCabalFile
+    findOrMakeCabalFile
   ) where
 
 import Control.Exception
 import Data.List
+import qualified Hpack as H
 import System.Directory
 import System.FilePath
 
@@ -13,14 +14,25 @@ import Stack2Cabal.StackYaml
   Local packages
 -------------------------------------------------------------------------------}
 
-findCabalFile :: LocalPackage -> IO FilePath
-findCabalFile dir = do
+-- | Return path of the cabal file of a local package. Stack supports hpack so
+-- we need to handle `package.yml` files as well. For those run hpack and return
+-- generated cabal file.
+findOrMakeCabalFile :: LocalPackage -> IO FilePath
+findOrMakeCabalFile dir = do
     files <- getDirectoryContents dir
     case filter isCabalFile files of
-      []   -> throwIO (userError notFound)
+      [] | elem "package.yaml" files
+           -> buildHpack
+         | otherwise
+           -> throwIO (userError notFound)
       [fp] -> return (dir </> fp)
       _    -> throwIO (userError multipleFound)
   where
+    buildHpack = do
+      let opts = H.setTarget (dir </> "package.yaml") H.defaultOptions
+      result <- H.hpackResult opts
+      return (H.resultCabalFile result)
+
     isCabalFile   = isSuffixOf ".cabal"
-    notFound      = "No .cabal file found in " ++ dir
+    notFound      = "No .cabal or package.yaml files found in " ++ dir
     multipleFound = "Multiple .cabal files found in " ++ dir

--- a/src/Stack2Cabal/RemotePkgs.hs
+++ b/src/Stack2Cabal/RemotePkgs.hs
@@ -46,7 +46,7 @@ locationLocalDir remPkgsDir Git{..} = remPkgsDir </> takeBaseName gitRepo
 
 remotePkgCabalFiles :: FilePath -> RemotePackage -> IO [FilePath]
 remotePkgCabalFiles remPkgsDir RemotePackage{..} =
-    mapM findCabalFile cabalDirs
+    mapM findOrMakeCabalFile cabalDirs
   where
     repoDir   = locationLocalDir remPkgsDir remPkgLocation
     cabalDirs = case remPkgSubdirs of

--- a/stack2cabal.cabal
+++ b/stack2cabal.cabal
@@ -30,6 +30,7 @@ executable stack2cabal
                      , directory
                      , filepath
                      , generics-sop
+                     , hpack
                      , http-conduit
                      , optparse-applicative
                      , process


### PR DESCRIPTION
stack automatically generates .cabal files from hpack files, so some
stack projects omit .cabal and only provide a hpack file. When a git
dependency is a stack project and only has a hpack file stack2cabal
currently fails when looking for a cabal file. We now handle this case
by running hpack and using the generated cabal file.

Fixes #2.